### PR TITLE
Only delete empty folders

### DIFF
--- a/components/delete-folder.tsx
+++ b/components/delete-folder.tsx
@@ -8,6 +8,7 @@ type DeleteFolderProps = {
 
 export default function DeleteFolder({ closeModal }: DeleteFolderProps) {
   const {
+    userNotes: { allNotes },
     userFolders: { folders, removeFolder },
     session: { setStatus },
   } = useStore();
@@ -20,9 +21,17 @@ export default function DeleteFolder({ closeModal }: DeleteFolderProps) {
   const handleSubmit = async (ev: FormEvent<HTMLFormElement>) => {
     ev.preventDefault();
 
-    setStatus("loading", "Deleting folder...");
-
     if (!folderId) return;
+
+    const folderNotEmpty = allNotes.some((note) => note.folder === folderId);
+
+    if (folderNotEmpty) {
+      setStatus("error", "Please empty folder before deleting...");
+
+      return;
+    }
+
+    setStatus("loading", "Deleting folder...");
 
     const remove = await removeFolder(folderId);
 

--- a/components/status-bar.tsx
+++ b/components/status-bar.tsx
@@ -29,6 +29,8 @@ export default function StatusBar() {
 
     timeout.current = setTimeout(() => {
       setVisible(false);
+
+      if (status === "error" || status === "ok") setStatus("idle");
     }, DELAY);
 
     return () => clear();
@@ -47,7 +49,7 @@ export default function StatusBar() {
 
   return (
     <div
-      className="zindex-2 absolute right-8 bottom-8 z-50 flex items-center rounded bg-light-3 px-4 py-3 text-dark-2 transition-opacity dark:bg-light-2 dark:text-dark-3"
+      className="absolute right-8 bottom-8 z-50 flex items-center rounded bg-light-3 px-4 py-3 text-dark-2 transition-opacity dark:bg-light-2 dark:text-dark-3"
       style={{ opacity: visible ? 1 : 0 }}
     >
       {StatusIcon[status]}


### PR DESCRIPTION
Why:
- When folders are deleted, the notes inside remain in the database, so now folders will have to be emptied before they can be deleted

How: 
- Checking if folder is empty before deleting, and showing an error message if they are not
- Also update status to `idle` after error or operation success