### PR TITLE
Filter out duplicate tags

### DIFF
--- a/lib/store.ts
+++ b/lib/store.ts
@@ -395,11 +395,14 @@ export const useStore = create<UseStore>()((set) => ({
           (previousTags, currentNote) => {
             if (!currentNote.tags) return [...previousTags];
 
+            const newTags = splitTags(currentNote.tags).filter(
+              (value, index, array) =>
+                index === array.findIndex((item) => item === value),
+            );
+
             return [
               ...previousTags,
-              ...splitTags(currentNote.tags).filter(
-                (tag) => !previousTags.includes(tag),
-              ),
+              ...newTags.filter((tag) => !previousTags.includes(tag)),
             ];
           },
           [] as string[],

--- a/lib/utils/split-tags.ts
+++ b/lib/utils/split-tags.ts
@@ -1,3 +1,3 @@
-const splitTags = (tags: string) => tags.split(/ *[,;\s] */).filter(Boolean);
+const splitTags = (tags: string) => tags.split(/ *[,;] */).filter(Boolean);
 
 export default splitTags;


### PR DESCRIPTION
Why: 
- If a note has a duplicate tag, the tag shows up twice in the tags list

How: 
- When defining the tags, filter out repeated words
- Also, allow tags to have spaces by splitting them only with `,` and `;`